### PR TITLE
fix: fix the source path 

### DIFF
--- a/plugin/skills/modernize-plan-create/SKILL.md
+++ b/plugin/skills/modernize-plan-create/SKILL.md
@@ -27,7 +27,7 @@ The modernization prompt is the only required parameter. Collect it first, then 
 
 **Optional Parameters:**
 
-- `--source`: Path to source project (relative or absolute local path). Default: current directory (`.`)
+- `--source`: Path to root of repository (relative or absolute local path). Default: current directory (`.`)
 - `--plan-name`: Name for this plan. Default: `modernization-plan`
 - `--language`: Project language (`java` or `dotnet`). Default: auto-detect
 - `--issue-url`: GitHub issue URL to link to this plan


### PR DESCRIPTION
This pull request updates the documentation for the `--source` parameter to clarify its purpose and usage.

- Documentation update:
  * Updated the description of the `--source` parameter in `plugin/skills/modernize-plan-create/SKILL.md` to specify that it refers to the path to the root of the repository, rather than just the source project.