### PR TITLE
Check task.json and generate plan name

### DIFF
--- a/plugin/skills/modernize-plan-create/SKILL.md
+++ b/plugin/skills/modernize-plan-create/SKILL.md
@@ -79,7 +79,7 @@ modernize plan create "<prompt>" [--source <path>] [--plan-name <name>] [--langu
 
 After execution:
 
-1. Read and present the generated plan from `.modernize/plans/<plan-name>/plan.md`
+1. Read and present the generated plan from `.modernize/plans/<plan-name>/plan.md` and `.modernize/plans/<plan-name>/tasks.json`
 2. Provide a summary of the plan's key phases and tasks
 3. Offer to explain any part of the plan in detail
 4. Suggest running `/modernize-run-plan` as a next step to execute the plan

--- a/plugin/skills/modernize-plan-create/SKILL.md
+++ b/plugin/skills/modernize-plan-create/SKILL.md
@@ -27,7 +27,7 @@ The modernization prompt is the only required parameter. Collect it first, then 
 **Optional Parameters:**
 
 - `--source`: Path to root of repository (relative or absolute local path). Default: current directory (`.`)
-- `--plan-name`: Name for this plan. Default: `modernization-plan`
+- `--plan-name`: Name for this plan. Generate a default name based on the prompt (e.g., "azure-migration-plan") if not provided
 - `--language`: Project language (`java` or `dotnet`). Default: auto-detect
 - `--issue-url`: GitHub issue URL to link to this plan
 

--- a/plugin/skills/modernize-plan-create/SKILL.md
+++ b/plugin/skills/modernize-plan-create/SKILL.md
@@ -27,7 +27,7 @@ The modernization prompt is the only required parameter. Collect it first, then 
 **Optional Parameters:**
 
 - `--source`: Path to root of repository (relative or absolute local path). Default: current directory (`.`)
-- `--plan-name`: Name for this plan. Generate a default name based on the prompt (e.g., "azure-migration-plan") if not provided
+- `--plan-name`: Name for this plan. Generate a name based on the prompt (e.g., "azure-migration-plan") if not provided. I will create a folder under `.github/modernize/`. The name should not duplicate existing plans in `.github/modernize/`.
 - `--language`: Project language (`java` or `dotnet`). Default: auto-detect
 - `--issue-url`: GitHub issue URL to link to this plan
 
@@ -79,7 +79,7 @@ modernize plan create "<prompt>" [--source <path>] [--plan-name <name>] [--langu
 
 After execution:
 
-1. Read and present the generated plan from `.modernize/plans/<plan-name>/plan.md` and `.modernize/plans/<plan-name>/tasks.json`
+1. Read and present the generated plan from `.github/modernize/plans/<plan-name>/plan.md` and `.github/modernize/plans/<plan-name>/tasks.json`
 2. Provide a summary of the plan's key phases and tasks
 3. Offer to explain any part of the plan in detail
 4. Suggest running `/modernize-run-plan` as a next step to execute the plan

--- a/plugin/skills/modernize-plan-execute/SKILL.md
+++ b/plugin/skills/modernize-plan-execute/SKILL.md
@@ -19,13 +19,14 @@ When the user invokes this command, follow these steps:
 
 Before collecting parameters, verify that a plan exists:
 
-1. Check for the plan at `.github/modernize/<plan-name>/plan.md` (default: `.github/modernize/modernization-plan/plan.md`)
+1. Check for the plan at `.github/modernize/<plan-name>` (default: `.github/modernize/modernization-plan`), there should be a `plan.md` and `tasks.json` file inside that directory
 2. If no plan exists, inform the user and suggest running `/modernize-create-plan` first
 3. If a plan exists, show a brief summary and ask for confirmation before proceeding
+4. If multiple plans are found, list them and ask the user to specify which one to execute using `--plan-name <plan-name>`
 
 **Example when no plan exists:**
 ```
-I couldn't find a modernization plan at `.github/modernize/modernization-plan/plan.md`.
+I couldn't find a modernization plan at `.github/modernize/<plan-name>`.
 
 Would you like me to:
 1. Create a new plan first using /modernize-create-plan
@@ -40,13 +41,13 @@ All parameters are optional with sensible defaults.
 
 - `prompt`: Specific instructions for executing the plan. Default: `execute the plan`
   - Prompt: "Any specific instructions for executing the plan? (Default: 'execute the plan')"
-- `--plan-name <plan-name>`: The name of the modernization plan. Default: `modernization-plan`
+- `--plan-name <plan-name>`: The name of the modernization plan. Default: `modernization-plan`, it is expected to be located at `.github/modernize/<plan-name>`
 - `--source <source>`: Path to source project (relative or absolute local path). Default: `.`
 - `--language <java|dotnet>`: The programming language for the modernization plan. Default: auto-detect
 
 **Example interaction:**
 ```
-I found the modernization plan at `.github/modernize/modernization-plan/plan.md`.
+I found the modernization plan at `.github/modernize/modernization-plan`.
 
 Plan Summary:
 - Phase 1: Update dependencies
@@ -65,7 +66,7 @@ Before executing, validate:
 
 - **`prompt`**: If provided, must not be empty
 - **`--language`**: If provided, must be either `java` or `dotnet` (case-insensitive)
-- **Plan exists**: Verify `.github/modernize/<plan-name>/plan.md` exists before attempting execution
+- **Plan exists**: Verify `.github/modernize/<plan-name>` exists before attempting execution
 
 If validation fails, explain the issue clearly and ask the user to provide a corrected value.
 
@@ -128,6 +129,6 @@ Claude: [Executes: modernize plan execute "focus on the dependency updates first
 **When no plan exists:**
 ```
 User: /modernize-run-plan
-Claude: I couldn't find a plan at `.github/modernize/modernization-plan/plan.md`.
+Claude: I couldn't find a plan at `.github/modernize/modernization-plan`.
         Would you like to create one first with /modernize-create-plan?
 ```


### PR DESCRIPTION
This pull request updates the documentation for the modernization plan creation and execution skills to clarify the plan directory structure, file locations, and naming conventions. The changes ensure consistency between plan creation and execution, and provide clearer instructions for users on how to specify and locate modernization plans.

**Plan directory and file structure updates:**

* Updated all references to the plan location from `.github/modernize/<plan-name>/plan.md` to `.github/modernize/plans/<plan-name>/plan.md` and `.github/modernize/plans/<plan-name>/tasks.json` in the plan creation documentation, and to `.github/modernize/<plan-name>` (containing both `plan.md` and `tasks.json`) in the execution documentation. [[1]](diffhunk://#diff-048dd2c9373d5977d7c407a03e52f25d9baa41b64f7a79ceb7dfdcaf26c6742dL82-R82) [[2]](diffhunk://#diff-df463e2e5d86ed9933305cdaf1d0e5e69bdf83b03d68fc95d67e206488664f64L22-R29) [[3]](diffhunk://#diff-df463e2e5d86ed9933305cdaf1d0e5e69bdf83b03d68fc95d67e206488664f64L43-R50) [[4]](diffhunk://#diff-df463e2e5d86ed9933305cdaf1d0e5e69bdf83b03d68fc95d67e206488664f64L68-R69) [[5]](diffhunk://#diff-df463e2e5d86ed9933305cdaf1d0e5e69bdf83b03d68fc95d67e206488664f64L131-R132)

**Plan naming and uniqueness:**

* Clarified that if `--plan-name` is not provided, a name should be generated based on the prompt (e.g., "azure-migration-plan") and must not duplicate existing plans in `.github/modernize/`.

**User experience improvements:**

* Added instructions to handle multiple existing plans by prompting the user to specify which plan to execute using `--plan-name <plan-name>`.

These changes improve clarity and help prevent confusion or errors when creating or executing modernization plans.